### PR TITLE
[MessagingSystemManager] Make more robust retry loop

### DIFF
--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/api/MessagingSystemManager.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/api/MessagingSystemManager.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.gemoc.commons.eclipse.messagingsystem.api;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.gemoc.commons.messagingsystem.api.impl.StdioSimpleMessagingSystem;

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/api/MessagingSystemManager.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/api/MessagingSystemManager.java
@@ -64,7 +64,7 @@ public class MessagingSystemManager {
 				result = (MessagingSystem) confElements[i].createExecutableExtension(MESSAGINGSYSTEM_EXTENSION_POINT_CONTRIB_MESSAGINGSYSTEM_ATT);
 				result.initialize(baseMessageGroup, userFriendlyName);
 				if(result != null)	break;
-			} catch (CoreException e) {;
+			} catch (Throwable t) {;
 			}
 		}
 		if (result == null){


### PR DESCRIPTION
I encountered a problem where the exception was not a `CoreException` but a cast exception. This change makes it more robust by catching any `Throwable`, and will make the code retry in such case as well.